### PR TITLE
Fix SELinux permission denied on /docker-entrypoint-initdb.d/

### DIFF
--- a/podman-compose.yaml
+++ b/podman-compose.yaml
@@ -25,7 +25,7 @@ services:
       - POSTGRES_DB=costmetrics
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./internal/db/migrations:/docker-entrypoint-initdb.d
+      - ./internal/db/migrations:/docker-entrypoint-initdb.d:Z
     ports:
       - "5432:5432"
     networks:


### PR DESCRIPTION
Add `:Z` option to the migrations volume mount in `podman-compose.yml` to fix SELinux permission denied errors on `/docker-entrypoint-initdb.d/.`